### PR TITLE
2024.12.1 ML Runtime adoption: using PBJ Workbench

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -6,7 +6,7 @@ prototype_version: 2.0
 date: "2022-04-14"
 
 runtimes:
-  - editor: Workbench
+  - editor: PBJ Workbench
     kernel: Python 3.9
     edition: Standard
 


### PR DESCRIPTION
Updated ML Runtime definition.

Testing: this is not an AMP we can "run", currently it fails during importing ray modules. Still, just to be _nice_ and not list a deprecated runtime variant, PBJ Workbench was added.